### PR TITLE
[feat] add papers related to index advisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,16 +119,25 @@ If the paper has the open-souce code, please supply its github links in Meeting
 
 ### Index Advisor
 
-1. [AI Meets AI: Leveraging Query Executions to Improve Index Recommendations](https://pages.cs.wisc.edu/~wentaowu/papers/sigmod19-auto-indexing.pdf) [SIGMOD 19]
-2. [Magic mirror in my hand, which is the best in the land? An Experimental Evaluation of Index Selection Algorithms](http://www.vldb.org/VLDB/vol13/p2382-kossmann.pdf) [[VLDB 20](https://github.com/hyrise/index_selection_evaluation/tree/rl_index_selection)]
-3. [An Index Advisor Using Deep Reinforcement Learning](https://baozhifeng.net/papers/cikm20-IndexRec.pdf) [[CIKM 20](https://github.com/rmitbggroup/IndexAdvisor)]
-4. [DBA bandits: Self-driving index tuning under ad-hoc, analytical workloads with safety guarantees ](https://arxiv.org/pdf/2010.09208) [ICDE 21]
-5. [AutoIndex: An Incremental Index Management System for Dynamic Workloads](https://dbgroup.cs.tsinghua.edu.cn/ligl/papers/icde2022-autoindex.pdf) [[ICDE 22](https://github.com/zhouxh19/AutoIndex)] 
-6. [SWIRL: Selection of Workload-aware Indexes using Reinforcement Learning ](https://openproceedings.org/2022/conf/edbt/paper-37.pdf) [[EDBT 22](https://github.com/hyrise/rl_index_selection)]
-7. [Budget-aware Index Tuning with Reinforcement Learning ](https://www.microsoft.com/en-us/research/uploads/prod/2022/06/mcts-full.pdf) [SIGMOD 22] 
-8. [DISTILL: low-overhead data-driven techniques for filtering and costing indexes for scalable index tuning](https://www.microsoft.com/en-us/research/uploads/prod/2022/06/DISTILL.pdf) [VLDB 22]
-9. [SmartIndex: An Index Advisor with Learned Cost Estimator](https://dl.acm.org/doi/abs/10.1145/3511808.3557163) [CIKM 22]
-10. [Learned Index Benefits: Machine Learning Based Index Performance Estimation](https://www.vldb.org/pvldb/vol15/p3950-shi.pdf) [[VLDB 23](https://github.com/JC-Shi/Learned-Index-Benefits)]
+1. [The Case for Automatic Database Administration using Deep Reinforcement Learning](https://arxiv.org/abs/1801.05643) [arXiv 18]
+2. [AI Meets AI: Leveraging Query Executions to Improve Index Recommendations](https://pages.cs.wisc.edu/~wentaowu/papers/sigmod19-auto-indexing.pdf) [SIGMOD 19]
+3. [Online Index Selection Using Deep Reinforcement Learning for a Cluster Database](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=9094124) [ICDEW 20] 
+4. [SMARTIX: A database indexing agent based on reinforcement learning](https://link.springer.com/article/10.1007/s10489-020-01674-8) [Applied Intelligence 20]
+5.  [Magic mirror in my hand, which is the best in the land? An Experimental Evaluation of Index Selection Algorithms](http://www.vldb.org/VLDB/vol13/p2382-kossmann.pdf) [[VLDB 20](https://github.com/hyrise/index_selection_evaluation/tree/rl_index_selection)]
+6. [An Index Advisor Using Deep Reinforcement Learning](https://baozhifeng.net/papers/cikm20-IndexRec.pdf) [[CIKM 20](https://github.com/rmitbggroup/IndexAdvisor)]
+7. [Automated Database Indexing Using Model-Free Reinforcement Learning](https://icaps20subpages.icaps-conference.org/wp-content/uploads/2020/10/SPARK-2020_paper_4.pdf) [ICAPS 20]
+8. [DBA bandits: Self-driving index tuning under ad-hoc, analytical workloads with safety guarantees ](https://arxiv.org/pdf/2010.09208) [ICDE 21]
+9. [Index selection for NoSQL database with deep reinforcement learning](https://www.sciencedirect.com/science/article/pii/S0020025521000049) [Information Sciences 21]
+10. [MANTIS: Multiple Type and Attribute Index Selection using Deep Reinforcement Learning](https://dl.acm.org/doi/10.1145/3472163.3472176) [IDEAS 21]
+11. [AutoIndex: An Incremental Index Management System for Dynamic Workloads](https://dbgroup.cs.tsinghua.edu.cn/ligl/papers/icde2022-autoindex.pdf) [[ICDE 22](https://github.com/zhouxh19/AutoIndex)] 
+12. [SWIRL: Selection of Workload-aware Indexes using Reinforcement Learning ](https://openproceedings.org/2022/conf/edbt/paper-37.pdf) [[EDBT 22](https://github.com/hyrise/rl_index_selection)]
+13. [Indexer++: Workload-Aware Online Index Tuning with Transformers and Reinforcement Learning](https://dl.acm.org/doi/abs/10.1145/3477314.3507691) [SAC 22]
+14. [Budget-aware Index Tuning with Reinforcement Learning ](https://www.microsoft.com/en-us/research/uploads/prod/2022/06/mcts-full.pdf) [SIGMOD 22] 
+15. [ISUM: Efficiently Compressing Large and Complex Workloads for Scalable Index Tuning](https://dl.acm.org/doi/10.1145/3514221.3526152) [SIGMOD 22]
+16. [DISTILL: low-overhead data-driven techniques for filtering and costing indexes for scalable index tuning](https://www.microsoft.com/en-us/research/uploads/prod/2022/06/DISTILL.pdf) [VLDB 22]
+17. [HMAB: Self-Driving Hierarchy of Bandits for Integrated Physical Database Design Tuning](https://www.vldb.org/pvldb/vol16/p216-perera.pdf) [[VLDB 22](https://github.com/malingaperera/HMAB)]
+18. [SmartIndex: An Index Advisor with Learned Cost Estimator](https://dl.acm.org/doi/abs/10.1145/3511808.3557163) [CIKM 22]
+19. [Learned Index Benefits: Machine Learning Based Index Performance Estimation](https://www.vldb.org/pvldb/vol15/p3950-shi.pdf) [[VLDB 23](https://github.com/JC-Shi/Learned-Index-Benefits)]
 
 ## Database Self-Tuning
 


### PR DESCRIPTION
From a more comprehensive perspective, I have added almost all the index recommendation papers based on the idea of machine learning in recent years, but I am no longer only adding top conference papers (i.e SIGMOD, VLDB, ICDE).